### PR TITLE
In response to issue #33

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -24,7 +24,7 @@ In both cases the event will fire _even if the browser is currently closed_, tho
 For specific use case examples, see the [use cases document](https://slightlyoff.github.io/BackgroundSync/use_cases.html).
 
 ## What Background Sync is not
-Background Sync is specifically not an exact alarm API. The scheduling granularity is in milliseconds but events may be delayed from firing for several hours if the device is resource constrained (e.g., low on battery). To run background events at exact times, consider using the [Push API](https://w3c.github.io/push-api/).
+Background Sync is specifically not an exact alarm API. The scheduling granularity is in milliseconds but events may be delayed from firing for several hours if the device is resource constrained (e.g., low on battery). Similarly, the user agent may ignore pending synchronization requests to accommodate for user expected behaviors on a given platform (e.g. Android's power saving mode does not allow background sync). To run background events at exact times, consider using the [Push API](https://w3c.github.io/push-api/).
 
 BackgroundSync also is not purposefully intended as a means to synchronize large files in the background (e.g., media), though it may be possible to use it to do so.
 


### PR DESCRIPTION
https://github.com/slightlyoff/BackgroundSync/issues/33

There might be some overlap with the previous sentence though:

> The scheduling granularity is in milliseconds but events may be delayed from firing for several hours if the device is resource constrained (e.g., low on battery)

Alternatively: The scheduling granularity is in milliseconds but events may be delayed from firing for several hours if the device is resource constrained (e.g., too busy). Similarly, the user agent may ignore pending synchronization requests to accommodate for user expected behaviors on a given platform (e.g. Android's power saving mode does not allow background sync).

Or perhaps the Pull Request was meant to be for the actual spec file?
Let me know.
